### PR TITLE
Fix minor typos in Lectures/*.lyx

### DIFF
--- a/Lectures/SS2.lyx
+++ b/Lectures/SS2.lyx
@@ -794,7 +794,7 @@ Fet stil eller ej spelar roll:
 \begin_inset Formula $P(x)$
 \end_inset
 
- är en enkel reel-värd funktion, precis som i vanlig analys.
+ är en enkel reellvärd funktion, precis som i vanlig analys.
 \end_layout
 
 \end_deeper
@@ -4223,7 +4223,7 @@ Chebyshevs olikhet: givet
 \end_inset
 
  med en sannolikhet som är åtminstone 
-\begin_inset Formula $1-\left(\sigma/\epsilon\right)^{2}$
+\begin_inset Formula $1-\left(\sigma/\varepsilon\right)^{2}$
 \end_inset
 
 .

--- a/Lectures/SS3.lyx
+++ b/Lectures/SS3.lyx
@@ -528,7 +528,7 @@ Var(X)=p\cdot q.
 \end_layout
 
 \begin_layout Itemize
-Bernoulliförsök: en sekvens av oberoende Bernoulli variabler, alla med sannolikh
+Bernoulliförsök: en sekvens av oberoende Bernoullivariabler, alla med sannolikh
 et 
 \begin_inset Formula $p$
 \end_inset
@@ -1106,7 +1106,7 @@ Låt
 \begin_inset Formula $X_{1},X_{2},...$
 \end_inset
 
- vara en sekvens Bernoulli försök med sannolikhet 
+ vara en sekvens Bernoulliförsök med sannolikhet
 \begin_inset Formula $p$
 \end_inset
 

--- a/Lectures/SS4.lyx
+++ b/Lectures/SS4.lyx
@@ -330,7 +330,7 @@ Kontinuerliga slumpvariabler
 
 \begin_deeper
 \begin_layout Itemize
-Kontinuerliga slumpvariabler kan anta alla reela värden på ett inteval 
+Kontinuerliga slumpvariabler kan anta alla reella värden på ett intervall
 \begin_inset Formula $(a,b)$
 \end_inset
 
@@ -1532,7 +1532,7 @@ Täthet för
 
 \begin_inset Formula 
 \[
-f(x)=\frac{1}{B(\alpha,\beta)}x^{\alpha-1}(1-x)^{\beta-1}\quad\text{for }0\leq x\leq1
+f(x)=\frac{1}{B(\alpha,\beta)}x^{\alpha-1}(1-x)^{\beta-1}\quad\text{för }0\leq x\leq1
 \]
 
 \end_inset

--- a/Lectures/SS7.lyx
+++ b/Lectures/SS7.lyx
@@ -374,7 +374,7 @@ Stickprov
 \series default
 \color inherit
  (eng.
- sample) = en delmängd av observerad enheter från populationen.
+ sample) = en delmängd av observerade enheter från populationen.
 \end_layout
 
 \begin_deeper

--- a/Lectures/SS8.lyx
+++ b/Lectures/SS8.lyx
@@ -338,7 +338,7 @@ parametrar
 
 \begin_deeper
 \begin_layout Itemize
-Ex medelinkomsten i Sveriges: populationens väntevärde 
+Ex medelinkomsten i Sverige: populationens väntevärde
 \begin_inset Formula $\mu$
 \end_inset
 
@@ -1881,7 +1881,7 @@ Ex.
 \end_inset
 
  är ML-skattningen.
- Med hur säkra är vi?
+ Men hur säkra är vi?
 \end_layout
 
 \begin_layout Itemize

--- a/Lectures/SS9.lyx
+++ b/Lectures/SS9.lyx
@@ -873,7 +873,7 @@ Steg vid hypotestest
 Välj 
 \series bold
 \color blue
-teststatistiska
+teststatistika
 \series default
 \color black
 , 
@@ -1031,7 +1031,7 @@ Steg vid hypotestest - Bernoulliexempel
 
 \series bold
 \color blue
-Teststatistiska
+Teststatistika
 \series default
 \color black
 , 
@@ -1644,7 +1644,7 @@ P-värde
 \end_layout
 
 \begin_layout Itemize
-Alternativ definition: Sannolikheten att acceptera en teststatistiska som
+Alternativ definition: Sannolikheten att acceptera en teststatistika som
  är lika extrem eller ännu mer extrem än 
 \begin_inset Formula $T_{obs}$
 \end_inset
@@ -1909,7 +1909,7 @@ status open
 
 \series bold
 \color blue
-Chi-två statistiskan
+Chi-två statistikan
 \color inherit
 
 \begin_inset Formula 


### PR DESCRIPTION
- SS2.lyx
  The change from \epsilon to \varepsilon is
  not really a typo but just to make it consistent
  with the other uses of \varepsilon on that slide.
